### PR TITLE
Feat/alpaca 1479 to 1482 implement reentrancy guard

### DIFF
--- a/contracts/6.12/stablecoin-core/LiquidationEngine.sol
+++ b/contracts/6.12/stablecoin-core/LiquidationEngine.sol
@@ -230,7 +230,7 @@ contract LiquidationEngine is
     bytes32 collateralPoolId,
     address positionAddress,
     address liquidatorAddress
-  ) external returns (uint256 id) {
+  ) external nonReentrant returns (uint256 id) {
     require(live == 1, "LiquidationEngine/not-live");
 
     (uint256 positionLockedCollateral, uint256 positionDebtShare) =

--- a/contracts/6.12/stablecoin-core/StabilityFeeCollector.sol
+++ b/contracts/6.12/stablecoin-core/StabilityFeeCollector.sol
@@ -193,7 +193,7 @@ contract StabilityFeeCollector is
   }
 
   // --- Stability Fee Collection ---
-  function collect(bytes32 collateralPool) external returns (uint256 rate) {
+  function collect(bytes32 collateralPool) external nonReentrant returns (uint256 rate) {
     require(now >= collateralPools[collateralPool].lastAccumulationTime, "StabilityFeeCollector/invalid-now");
     (, uint256 prev) = government.collateralPools(collateralPool);
     rate = rmul(

--- a/contracts/6.12/stablecoin-core/SystemDebtEngine.sol
+++ b/contracts/6.12/stablecoin-core/SystemDebtEngine.sol
@@ -159,14 +159,14 @@ contract SystemDebtEngine is
   }
 
   // Pop from debt-queue
-  function popFromBadDebtQueue(uint256 timestamp) external {
+  function popFromBadDebtQueue(uint256 timestamp) external nonReentrant {
     require(add(timestamp, badDebtAuctionDelay) <= now, "SystemDebtEngine/badDebtAuctionDelay-not-finished");
     totalBadDebtValue = sub(totalBadDebtValue, badDebtQueue[timestamp]);
     badDebtQueue[timestamp] = 0;
   }
 
   // Debt settlement
-  function settleSystemBadDebt(uint256 rad) external {
+  function settleSystemBadDebt(uint256 rad) external nonReentrant {
     require(rad <= government.dai(address(this)), "SystemDebtEngine/insufficient-surplus");
     require(
       rad <= sub(sub(government.systemBadDebt(address(this)), totalBadDebtValue), totalBadDebtInAuction),
@@ -175,7 +175,7 @@ contract SystemDebtEngine is
     government.settleSystemBadDebt(rad);
   }
 
-  function settleSystemBadDebtByAuction(uint256 rad) external {
+  function settleSystemBadDebtByAuction(uint256 rad) external nonReentrant {
     require(rad <= totalBadDebtInAuction, "SystemDebtEngine/not-enough-ash");
     require(rad <= government.dai(address(this)), "SystemDebtEngine/insufficient-surplus");
     totalBadDebtInAuction = sub(totalBadDebtInAuction, rad);
@@ -183,7 +183,7 @@ contract SystemDebtEngine is
   }
 
   // Debt auction
-  function startBadDebtAuction() external returns (uint256 id) {
+  function startBadDebtAuction() external nonReentrant returns (uint256 id) {
     require(
       badDebtFixedBidSize <=
         sub(sub(government.systemBadDebt(address(this)), totalBadDebtValue), totalBadDebtInAuction),
@@ -195,7 +195,7 @@ contract SystemDebtEngine is
   }
 
   // Surplus auction
-  function startSurplusAuction() external returns (uint256 id) {
+  function startSurplusAuction() external nonReentrant returns (uint256 id) {
     require(
       government.dai(address(this)) >=
         add(add(government.systemBadDebt(address(this)), surplusAuctionFixedLotSize), surplusBuffer),

--- a/contracts/6.12/stablecoin-core/adapters/IbTokenAdapter.sol
+++ b/contracts/6.12/stablecoin-core/adapters/IbTokenAdapter.sol
@@ -159,7 +159,7 @@ contract IbTokenAdapter is
     address positionAddress,
     address usr,
     uint256 val
-  ) public override {
+  ) public override nonReentrant {
     super.deposit(positionAddress, usr, val);
     fairlaunch.deposit(address(this), pid, val);
   }
@@ -168,14 +168,14 @@ contract IbTokenAdapter is
     address urn,
     address usr,
     uint256 val
-  ) public override {
+  ) public override nonReentrant {
     if (live == 1) {
       fairlaunch.withdraw(address(this), pid, val);
     }
     super.withdraw(urn, usr, val);
   }
 
-  function emergencyWithdraw(address urn, address usr) public override {
+  function emergencyWithdraw(address urn, address usr) public override nonReentrant {
     if (live == 1) {
       uint256 val = government.collateralToken(collateralPoolId, urn);
       fairlaunch.withdraw(address(this), pid, val);
@@ -183,7 +183,7 @@ contract IbTokenAdapter is
     super.emergencyWithdraw(urn, usr);
   }
 
-  function cage() public override {
+  function cage() public override nonReentrant {
     require(live == 1, "IbTokenAdapter/not-live");
 
     // Allow caging if any assumptions change

--- a/contracts/6.12/stablecoin-core/adapters/StablecoinAdapter.sol
+++ b/contracts/6.12/stablecoin-core/adapters/StablecoinAdapter.sol
@@ -132,12 +132,12 @@ contract StablecoinAdapter is
     require(y == 0 || (z = x * y) / y == x);
   }
 
-  function deposit(address usr, uint256 wad) external {
+  function deposit(address usr, uint256 wad) external nonReentrant {
     government.moveStablecoin(address(this), usr, mul(ONE, wad));
     stablecoin.burn(msg.sender, wad);
   }
 
-  function withdraw(address usr, uint256 wad) external {
+  function withdraw(address usr, uint256 wad) external nonReentrant {
     require(live == 1, "StablecoinAdapter/not-live");
     government.moveStablecoin(msg.sender, address(this), mul(ONE, wad));
     stablecoin.mint(usr, wad);

--- a/contracts/6.12/stablecoin-core/adapters/TokenAdapter.sol
+++ b/contracts/6.12/stablecoin-core/adapters/TokenAdapter.sol
@@ -129,14 +129,14 @@ contract TokenAdapter is OwnableUpgradeable, PausableUpgradeable, AccessControlU
     live = 0;
   }
 
-  function deposit(address usr, uint256 wad) external {
+  function deposit(address usr, uint256 wad) external nonReentrant {
     require(live == 1, "TokenAdapter/not-live");
     require(int256(wad) >= 0, "TokenAdapter/overflow");
     government.addCollateral(collateralPoolId, usr, int256(wad));
     require(collateralToken.transferFrom(msg.sender, address(this), wad), "TokenAdapter/failed-transfer");
   }
 
-  function withdraw(address usr, uint256 wad) external {
+  function withdraw(address usr, uint256 wad) external nonReentrant {
     require(wad <= 2**255, "TokenAdapter/overflow");
     government.addCollateral(collateralPoolId, msg.sender, -int256(wad));
     require(collateralToken.transfer(usr, wad), "TokenAdapter/failed-transfer");

--- a/contracts/6.12/stablecoin-core/auctioneers/CollateralAuctioneer.sol
+++ b/contracts/6.12/stablecoin-core/auctioneers/CollateralAuctioneer.sol
@@ -543,7 +543,7 @@ contract CollateralAuctioneer is
   }
 
   // Public function to update the cached debtFloor*liquidationPenalty value.
-  function updateMinimumRemainingDebt() external {
+  function updateMinimumRemainingDebt() external nonReentrant {
     (, , , , uint256 _debtFloor) = GovernmentLike(government).collateralPools(collateralPoolId);
     minimumRemainingDebt = wmul(_debtFloor, liquidationEngine.liquidationPenalty(collateralPoolId));
   }

--- a/contracts/6.12/stablecoin-core/auctioneers/FarmableTokenAuctioneer.sol
+++ b/contracts/6.12/stablecoin-core/auctioneers/FarmableTokenAuctioneer.sol
@@ -579,7 +579,7 @@ contract FarmableTokenAuctioneer is
   }
 
   // Public function to update the cached debtFloor*liquidationPenalty value.
-  function updateMinimumRemainingDebt() external {
+  function updateMinimumRemainingDebt() external nonReentrant {
     (, , , , uint256 _debtFloor) = GovernmentLike(government).collateralPools(collateralPoolId);
     minimumRemainingDebt = wmul(_debtFloor, liquidationEngine.liquidationPenalty(collateralPoolId));
   }


### PR DESCRIPTION
## Description
Apply reentrancy guard to IbTokenAdapter, StablecoinAdapter, TokenAdapter, CollateralAuctioneer, FarmableTokenAuctioneer, LiquidationEngine, SystemDebtEngine, StabilityFeeCollector contract