### PR TITLE
[main][refactor][alpaca-1491] extract interface from calculator module

### DIFF
--- a/contracts/6.12/interfaces/ICalculator.sol
+++ b/contracts/6.12/interfaces/ICalculator.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.6.12;
+
+interface ICalculator {
+  // 1st arg: initial price               [ray]
+  // 2nd arg: seconds since auction start [seconds]
+  // returns: current auction price       [ray]
+  function price(uint256, uint256) external view returns (uint256);
+}

--- a/contracts/6.12/stablecoin-core/calculators/ExponentialDecrease.sol
+++ b/contracts/6.12/stablecoin-core/calculators/ExponentialDecrease.sol
@@ -15,19 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.6.12;
+pragma solidity 0.6.12;
 
-interface Calculator {
-  // 1st arg: initial price               [ray]
-  // 2nd arg: seconds since auction start [seconds]
-  // returns: current auction price       [ray]
-  function price(uint256, uint256) external view returns (uint256);
-}
+import "../../interfaces/ICalculator.sol";
 
 // While an equivalent function can be obtained by setting step = 1 in StairstepExponentialDecrease,
 // this continous (i.e. per-second) exponential decrease has be implemented as it is more gas-efficient
 // than using the stairstep version with step = 1 (primarily due to 1 fewer SLOAD per price calculation).
-contract ExponentialDecrease is Calculator {
+contract ExponentialDecrease is ICalculator {
   // --- Auth ---
   mapping(address => uint256) public wards;
 

--- a/contracts/6.12/stablecoin-core/calculators/LinearDecrease.sol
+++ b/contracts/6.12/stablecoin-core/calculators/LinearDecrease.sol
@@ -15,16 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.6.12;
+pragma solidity 0.6.12;
 
-interface Calculator {
-  // 1st arg: initial price               [ray]
-  // 2nd arg: seconds since auction start [seconds]
-  // returns: current auction price       [ray]
-  function price(uint256, uint256) external view returns (uint256);
-}
+import "../../interfaces/ICalculator.sol";
 
-contract LinearDecrease is Calculator {
+contract LinearDecrease is ICalculator {
   // --- Auth ---
   mapping(address => uint256) public wards;
 

--- a/contracts/6.12/stablecoin-core/calculators/StairstepExponentialDecrease.sol
+++ b/contracts/6.12/stablecoin-core/calculators/StairstepExponentialDecrease.sol
@@ -15,16 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.6.12;
+pragma solidity 0.6.12;
 
-interface Calculator {
-  // 1st arg: initial price               [ray]
-  // 2nd arg: seconds since auction start [seconds]
-  // returns: current auction price       [ray]
-  function price(uint256, uint256) external view returns (uint256);
-}
+import "../../interfaces/ICalculator.sol";
 
-contract StairstepExponentialDecrease is Calculator {
+contract StairstepExponentialDecrease is ICalculator {
   // --- Auth ---
   mapping(address => uint256) public wards;
 


### PR DESCRIPTION
## Description 
Refactor interfaces in `calculator` module from `calculator` to `ICalculator` and import them instead of declaring on every files.

Following interfaces are affected

- ExponentialDecrease
- LinearDecrease
- StairstepExponentialDecrease