### PR TITLE
[main] [fix] add system bad debt check before withdraw surplus

### DIFF
--- a/contracts/6.12/stablecoin-core/SystemDebtEngine.sol
+++ b/contracts/6.12/stablecoin-core/SystemDebtEngine.sol
@@ -94,6 +94,7 @@ contract SystemDebtEngine is
   /// @param value The value of collateral. [rad]
   function withdrawStablecoinSurplus(address to, uint256 value) external {
     require(hasRole(OWNER_ROLE, msg.sender), "!ownerRole");
+    require(bookKeeper.systemBadDebt(address(this)) == 0, "SystemDebtEngine/system-bad-debt-remaining");
     require(sub(bookKeeper.stablecoin(address(this)), value) >= surplusBuffer, "SystemDebtEngine/insufficient-surplus");
     bookKeeper.moveStablecoin(address(this), to, value);
   }


### PR DESCRIPTION
Add System Bad Debt check before withdraw Stablecoin Surplus to be more transparent by forcing the System Bad Debt to be cleared first.