### PR TITLE
[main][feat] Add zero check for left over stablecoin in AlpacaStablecoinProxyActions

### DIFF
--- a/.testnet.json
+++ b/.testnet.json
@@ -9,7 +9,7 @@
     "deployedBlock": 0
   },
   "AlpacaStablecoinProxyActions": {
-    "address": "0x0F09B63F9aFE060Fc46f2B03fcd8218E973d879D",
+    "address": "0x0E6287b34e505DceB71bE574227e07a3A5c078C0",
     "deployedBlock": 0
   },
   "AccessControlConfig": {

--- a/.testnet.json
+++ b/.testnet.json
@@ -9,7 +9,7 @@
     "deployedBlock": 0
   },
   "AlpacaStablecoinProxyActions": {
-    "address": "0xADAfBd9BC3A4310caD3Fd771C3Ac8b401793b438",
+    "address": "0x0F09B63F9aFE060Fc46f2B03fcd8218E973d879D",
     "deployedBlock": 0
   },
   "AccessControlConfig": {

--- a/contracts/6.12/proxy-actions/AlpacaStablecoinProxyActions.sol
+++ b/contracts/6.12/proxy-actions/AlpacaStablecoinProxyActions.sol
@@ -124,7 +124,9 @@ contract AlpacaStablecoinProxyActions {
     // Gets actual stablecoin amount in the usr
     uint256 _stablecoinValue = IBookKeeper(_bookKeeper).stablecoin(_usr); // [rad]
 
-    uint256 _requiredStablecoinValue = _safeSub(_safeMul(_debtShare, _debtAccumulatedRate), _stablecoinValue); // [rad]
+    uint256 _requiredStablecoinValue = _debtShare == 0
+      ? 0
+      : _safeSub(_safeMul(_debtShare, _debtAccumulatedRate), _stablecoinValue); // [rad]
     _requiredStablecoinAmount = _requiredStablecoinValue / RAY; // [wad] = [rad]/[ray]
 
     // If the value precision has some dust, it will need to request for 1 extra amount wei

--- a/contracts/6.12/proxy-actions/AlpacaStablecoinProxyActions.sol
+++ b/contracts/6.12/proxy-actions/AlpacaStablecoinProxyActions.sol
@@ -124,9 +124,10 @@ contract AlpacaStablecoinProxyActions {
     // Gets actual stablecoin amount in the usr
     uint256 _stablecoinValue = IBookKeeper(_bookKeeper).stablecoin(_usr); // [rad]
 
-    uint256 _requiredStablecoinValue = _debtShare == 0
-      ? 0
-      : _safeSub(_safeMul(_debtShare, _debtAccumulatedRate), _stablecoinValue); // [rad]
+    uint256 _positionDebtValue = _safeMul(_debtShare, _debtAccumulatedRate);
+    uint256 _requiredStablecoinValue = _positionDebtValue >= _stablecoinValue
+      ? _safeSub(_positionDebtValue, _stablecoinValue)
+      : 0; // [rad]
     _requiredStablecoinAmount = _requiredStablecoinValue / RAY; // [wad] = [rad]/[ray]
 
     // If the value precision has some dust, it will need to request for 1 extra amount wei


### PR DESCRIPTION
## Description
When calling any `wipeAll` function, the code will calculate the amount of AUSD needed to repay all of the debt. There is a precision loss protection which will add 1 wei as a buffer. This leftover AUSD after `wipeAll` will affect any subsequent `wipeAll` calls to that position. This PR solves this problem by adding check if the AUSD value inside the position address is more than position debt value, then we just don't ask for any more AUSD from the users.