### PR TITLE
[main][fix] IbTokenPriceFeed Issue

### DIFF
--- a/contracts/6.12/price-feeders/IbTokenPriceFeed.sol
+++ b/contracts/6.12/price-feeders/IbTokenPriceFeed.sol
@@ -50,7 +50,7 @@ contract IbTokenPriceFeed is PausableUpgradeable, AccessControlUpgradeable, IPri
     address _ibInBasePriceFeed,
     address _baseInUsdPriceFeed,
     address _accessControlConfig,
-    uint16 _timeDelay
+    uint256 _timeDelay
   ) external initializer {
     PausableUpgradeable.__Pausable_init();
     AccessControlUpgradeable.__AccessControl_init();

--- a/test/units/price-feeders/IbTokenPriceFeed.test.ts
+++ b/test/units/price-feeders/IbTokenPriceFeed.test.ts
@@ -106,12 +106,10 @@ describe("IbTokenPriceFeed", () => {
         // 1 BNB = 400 USD
         mockedBaseUsdPriceFeed.smocked.peekPrice.will.return.with([formatBytes32BigNumber(parseEther("400")), true])
 
-        await ibTokenPriceFeed.setPrice()
+        await expect(ibTokenPriceFeed.setPrice()).to.be.revertedWith("IbTokenPriceFeed/not-ok")
         assertPeekPriceCall(mockedIbBasePriceFeed.smocked.peekPrice.calls)
         assertPeekPriceCall(mockedBaseUsdPriceFeed.smocked.peekPrice.calls)
 
-        TimeHelpers.increase(BigNumber.from(900))
-        await ibTokenPriceFeed.setPrice()
         const [price, ok] = await ibTokenPriceFeed.peekPrice()
         expect(BigNumber.from(price)).to.be.equal(0)
         expect(ok).to.be.false
@@ -124,12 +122,10 @@ describe("IbTokenPriceFeed", () => {
         // 1 BNB = 400 USD
         mockedBaseUsdPriceFeed.smocked.peekPrice.will.return.with([formatBytes32BigNumber(parseEther("400")), false])
 
-        await ibTokenPriceFeed.setPrice()
+        await expect(ibTokenPriceFeed.setPrice()).to.be.revertedWith("IbTokenPriceFeed/not-ok")
         assertPeekPriceCall(mockedIbBasePriceFeed.smocked.peekPrice.calls)
         assertPeekPriceCall(mockedBaseUsdPriceFeed.smocked.peekPrice.calls)
 
-        TimeHelpers.increase(BigNumber.from(900))
-        await ibTokenPriceFeed.setPrice()
         const [price, ok] = await ibTokenPriceFeed.peekPrice()
         expect(BigNumber.from(price)).to.be.equal(0)
         expect(ok).to.be.false


### PR DESCRIPTION
## Description
- Change from `uint16` to `uint256` for `_timeDelay` in `initialize()`
- Fix failed tests